### PR TITLE
Fix #23

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,11 @@
 								<div class="tweets-feed" id="tweets" data-count=50 data-query="fossasia #gci">
 									<div class="arrow-up"></div>
 									<p id="tweet" class="tweet">
-                    <div class="panel-footer">
-                      <span id="tweet-info"></span>
-                    </div>
+                    Loading...
                   </p>
+                  <div class="panel-footer">
+                    <span id="tweet-info">Fetching tweets...</span>
+                  </div>
 								</div>
 								<div class="btn" id="previous"onclick="lastTweet()">
 									&#8592; &nbsp; Previous Tweet!

--- a/js/tweets.js
+++ b/js/tweets.js
@@ -11,12 +11,12 @@ function interval() {
 
 function datafetcher() {
 	loklakFetcher.getTweets({}, datahandler);
-	interval();
 }
 
 function datahandler(raw) {
 	stuff = raw;   // Makes the data available globally.
 	parser(stuff);
+	interval();
 }
 
 var tweetNum = 0;


### PR DESCRIPTION
Now there shouldn't appear any errors if loklak API is taking too long to respond, to fix issue #23.
Aditionally, some feedback to tell the user the tweets are being loaded, has been added.

This has been tested with a simulated 10kb connection with 1s TTL, and worked without problems.
# Screenshot

![loklak webtweets loading](https://cloud.githubusercontent.com/assets/7356565/12374659/8f8c6056-bca2-11e5-83c8-ec6e261bdde0.png)
