### PR TITLE
Fixes tweets using new loklak syntax

### DIFF
--- a/js/loklak-fetcher.js
+++ b/js/loklak-fetcher.js
@@ -46,21 +46,21 @@ window.loklakFetcher = (function() {
       var query;
 
       if(dataset.query) {
-        query = dataset.query.replace(/\s/gi, '%20').replace(/#/gi, '%23'); //replace spaces and hashtags in URL
+        query = dataset.query.replace(/\s/gi, '&').replace(/#/gi, '%23'); //replace spaces and hashtags in URL
       } else {
         query = "fossasia";
       }
 
       if(dataset.start) {
-        query = query + "%20since:" + dataset.start;
+        query = query + "&since:" + dataset.start;
       }
 
       if(dataset.end) {
-        query = query + "%20until:" + dataset.end;
+        query = query + "&until:" + dataset.end;
       }
 
       if(dataset.from) {
-        query = query + "%20from:" + dataset.from;
+        query = query + "&from:" + dataset.from;
       }
 
       // Write unset options as their default
@@ -71,15 +71,16 @@ window.loklakFetcher = (function() {
       }
 
       // Create the URL with all the parameters
-      var url = 'http://loklak.org/api/search.json' +
+      var url = 'https://api.loklak.org/api/search.json' +
         '?callback=loklakFetcher.handleData' +
-        '&q=' + query +
+        '&q=' + query + 
         '&count=' + options.count +
         '&source=' + options.source +
         '&fields=' + options.fields +
         '&limit=' + options.limit +
         '&timezoneOffset=' + options.tzOffset +
         '&minified=' + options.minified;
+
       // If the script element for JSONP already exists, remove it
       if(script !== null) {
         document.head.removeChild(script);


### PR DESCRIPTION
Fixes: #27 
Tweets are now fetched from https://api.loklak.org without any error.

Demo: https://geekyd.github.io/loklak-webtweets

@mariobehling Please review this.